### PR TITLE
Mock out _turn_deque on MagicFolders during tests

### DIFF
--- a/src/allmydata/test/test_cli_magic_folder.py
+++ b/src/allmydata/test/test_cli_magic_folder.py
@@ -105,6 +105,7 @@ class MagicFolderCLITestMixin(CLITestMixin, GridTestMixin):
         dbfile = abspath_expanduser_unicode(u"magicfolderdb.sqlite", base=self.get_clientdir(i=client_num))
         magicfolder = MagicFolder(self.get_client(client_num), upload_dircap, collective_dircap, local_magic_dir,
                                        dbfile, pending_delay=0.2, clock=clock)
+        magicfolder.downloader._turn_delay = 0
         magicfolder.setServiceParent(self.get_client(client_num))
         magicfolder.ready()
         return magicfolder

--- a/src/allmydata/test/test_magic_folder.py
+++ b/src/allmydata/test/test_magic_folder.py
@@ -53,6 +53,20 @@ class MagicFolderTestMixin(MagicFolderCLITestMixin, ShouldFailMixin, ReallyEqual
     def _wait_until_started(self, ign):
         #print "_wait_until_started"
         self.magicfolder = self.get_client().getServiceNamed('magic-folder')
+
+        # mock out the two _when_queue_empty calls so we control when
+        # the queue runs, via self._do_download and self._do_upload We
+        # set _turn_delay to 0 so that there aren't any "deferLater"
+        # calls sitting in the _lazy_tail chain that actually need to
+        # wait. All this has to happen before .ready() since that
+        # queues a deferLater.
+        self.magicfolder = self.get_client().getServiceNamed('magic-folder')
+        self._do_download = self.magicfolder.downloader._when_queue_is_empty
+        self._do_upload = self.magicfolder.uploader._when_queue_is_empty
+        self.magicfolder.downloader._turn_delay = 0
+        self.magicfolder.downloader._when_queue_is_empty = lambda: defer.succeed(None)
+        self.magicfolder.uploader._when_queue_is_empty = lambda: defer.succeed(None)
+
         return self.magicfolder.ready()
 
     def test_db_basic(self):
@@ -311,8 +325,8 @@ class MagicFolderTestMixin(MagicFolderCLITestMixin, ShouldFailMixin, ReallyEqual
         self.failUnlessEqual(version, expected_version)
 
     def test_alice_bob(self):
-        clock = Clock()
-        d = self.setup_alice_and_bob(clock=clock)
+        d = self.setup_alice_and_bob()
+
         def get_results(result):
             # XXX are these used?
             (self.alice_collective_dircap, self.alice_upload_dircap, self.alice_magicfolder,
@@ -321,19 +335,24 @@ class MagicFolderTestMixin(MagicFolderCLITestMixin, ShouldFailMixin, ReallyEqual
             #print "Bob   magicfolderdb is at %r" % (self.bob_magicfolder._client.basedir)
         d.addCallback(get_results)
 
+        def mock_deque_infinite_loop(_):
+            self._do_bob_download = self.bob_magicfolder.downloader._when_queue_is_empty
+            self._do_alice_download = self.alice_magicfolder.downloader._when_queue_is_empty
+            self.bob_magicfolder.downloader._when_queue_is_empty = lambda: defer.succeed(None)
+            self.alice_magicfolder.downloader._when_queue_is_empty = lambda: defer.succeed(None)
+        d.addCallback(mock_deque_infinite_loop)
+
         def Alice_write_a_file(result):
             print "Alice writes a file\n"
             self.file_path = abspath_expanduser_unicode(u"file1", base=self.alice_magicfolder.uploader._local_path_u)
             fileutil.write(self.file_path, "meow, meow meow. meow? meow meow! meow.")
             self.magicfolder = self.alice_magicfolder
             self.notify(to_filepath(self.file_path), self.inotify.IN_CLOSE_WRITE)
-            clock.advance(4)
         d.addCallback(Alice_write_a_file)
 
         def Alice_wait_for_upload(result):
             print "Alice waits for an upload\n"
             d2 = self.alice_magicfolder.uploader.set_hook('processed')
-            clock.advance(4)
             return d2
 
         d.addCallback(Alice_wait_for_upload)
@@ -349,11 +368,15 @@ class MagicFolderTestMixin(MagicFolderCLITestMixin, ShouldFailMixin, ReallyEqual
 
         def Bob_wait_for_download(result):
             print "Bob waits for a download\n"
-            clock.advance(4)
             d2 = self.bob_magicfolder.downloader.set_hook('processed')
+            self._do_bob_download()
             return d2
 
-        d.addCallback(Bob_wait_for_download)
+        # XXX I think what's happening is that when we started the
+        # downloader, one _turn_deque was already queued for the
+        # downloader, so Bob has already done his download by now.
+        #d.addCallback(Bob_wait_for_download)
+
         d.addCallback(lambda ign: self._check_version_in_local_db(self.bob_magicfolder, u"file1", 0))
         d.addCallback(lambda ign: self._check_version_in_dmd(self.bob_magicfolder, u"file1", 0)) # XXX prolly not needed
         d.addCallback(lambda ign: self.failUnlessReallyEqual(self._get_count('downloader.objects_failed'), 0))
@@ -364,7 +387,6 @@ class MagicFolderTestMixin(MagicFolderCLITestMixin, ShouldFailMixin, ReallyEqual
             print "Alice deletes the file!\n"
             os.unlink(self.file_path)
             self.notify(to_filepath(self.file_path), self.inotify.IN_DELETE)
-            clock.advance(4)
             return None
 
         d.addCallback(Alice_delete_file)
@@ -386,7 +408,6 @@ class MagicFolderTestMixin(MagicFolderCLITestMixin, ShouldFailMixin, ReallyEqual
             fileutil.write(self.file_path, "Alice suddenly sees the white rabbit running into the forest.")
             self.magicfolder = self.alice_magicfolder
             self.notify(to_filepath(self.file_path), self.inotify.IN_CLOSE_WRITE)
-            clock.advance(4)
 
         d.addCallback(lambda ign: self._check_version_in_local_db(self.bob_magicfolder, u"file1", 1))
         d.addCallback(Alice_rewrite_file)
@@ -414,7 +435,6 @@ class MagicFolderTestMixin(MagicFolderCLITestMixin, ShouldFailMixin, ReallyEqual
             d2 = self.bob_magicfolder.finish()
             d.addBoth(lambda ign: d2)
             d.addCallback(lambda ign: result)
-            clock.advance(4)
             return d
         d.addCallback(cleanup_Alice_and_Bob)
         return d


### PR DESCRIPTION
Here's an alternative idea for making the tests run faster -- instead of using a Clock instance to drive the tests forward faster, we mock out the _turn_deque calls in MagicFolder and use the originals to drive forward the download/upload queue as required by the tests.

From my testing, this works fine for both the MockTest and RealTest variants.
